### PR TITLE
Simplify parser rules for left hand expressions

### DIFF
--- a/parser.lua
+++ b/parser.lua
@@ -160,19 +160,19 @@ local patt = [[
       "local" <idsafe> s {| <name_list> |} (s "=" s {| <expr_list> |})?
    ) -> localDecl
 
-   patt <- (
+   left_pattern <- (
       <array_patt> / <table_patt> / <member_expr>
    )
 
    array_patt <- (
-      "[" s {| <patt> (s "," s <patt>)* |} "]"
+      "[" s {| <left_pattern> (s "," s <left_pattern>)* |} "]"
    ) -> arrayPatt
 
    table_patt <- (
       "{" s {| <table_patt_pair> (s "," s <table_patt_pair>)* |} "}"
    ) -> tablePatt
    table_patt_pair <- (
-      (<literal> / <ident>) s ":" s <patt>
+      (<literal> / <ident>) s ":" s <left_pattern>
    )
 
    name_list <- (
@@ -369,17 +369,12 @@ local patt = [[
       / "|=" / "&=" / "^=" / "<<=" / ">>>=" / ">>="
    }
 
-   left_expr <- (
-      <patt> / <ident>
-      -- <member_expr> / <ident>
-   )
-
    assign_expr <- (
-      {| <left_expr> (s "," s <left_expr>)* |} s "=" s {| <expr_list> |}
+      {| <left_pattern> (s "," s <left_pattern>)* |} s "=" s {| <expr_list> |}
    ) -> assignExpr
 
    update_expr <- (
-      <left_expr> s <assop> s <expr>
+      <left_pattern> s <assop> s <expr>
    ) -> updateExpr
 
    array_expr <- (


### PR DESCRIPTION
Hi Richard,

I propose here a small simplification of the parser. I've noticed that the rule:

```
   left_expr <- (
      <patt> / <ident>
   )
```

is not needed since <patt> include already the case of the simple identifier. I've therefore identified left_expr with patt and renamed this latter left_pattern to be more clear.

Francesco
