### PR TITLE
Fix problem with string's escape sequences

### DIFF
--- a/parser.lua
+++ b/parser.lua
@@ -34,8 +34,10 @@ local patt = [[
 
    sep <- <bcomment>? (%nl / ";" / &"}" / <lcomment>) / %s <sep>?
 
-   astring <- "'" { (!"'" .)* } "'"
-   qstring <- '"' { (!'"' .)* } '"'
+   escape <- {~ ('\' (%digit^3 / .)) -> escape ~}
+
+   astring <- "'" {~ (<escape> / {!"'" .})* ~} "'"
+   qstring <- '"' {~ (<escape> / {!'"' .})* ~} '"'
    lstring <- ('[' {:eq: '='* :} '[' <close>)
 
    special <- "\n" "\$" / "\\" / "\" .
@@ -50,9 +52,7 @@ local patt = [[
       "${" s <expr> s "}"
    ) -> rawExpr
 
-   string  <- (
-      <qstring> / <astring> / <lstring>
-   ) -> string
+   string  <- <qstring> / <astring> / <lstring>
 
    hexnum <- "-"? "0x" %xdigit+
 

--- a/parser/defs.lua
+++ b/parser/defs.lua
@@ -13,6 +13,26 @@ end
 function defs.quote(s)
    return string.format("%q", s)
 end
+local escape_lookup = {
+   ["a"] = "\a",
+   ["b"] = "\b",
+   ["f"] = "\f",
+   ["n"] = "\n",
+   ["r"] = "\r",
+   ["t"] = "\t",
+   ["v"] = "\v",
+   ["0"] = "\0",
+   ['"'] = '"',
+   ["'"] = "'",
+   ["\\"]= "\\"
+}
+function defs.escape(s)
+   local t = string.sub(s, 2)
+   local n = tonumber(t)
+   if n then return string.char(n) end
+   if escape_lookup[t] then return escape_lookup[t] end
+   error("invalid escape sequence")
+end
 function defs.chunk(body)
    return { type = "Chunk", body = body }
 end
@@ -64,16 +84,6 @@ function defs.fail(src, pos, msg)
       local tok = string.match(src, '(%w+)', pos) or loc
       error(msg.." near '"..tok.."'")
    end
-end
-
-local strEscape = {
-   ["\\r"] = "\r",
-   ["\\n"] = "\n",
-   ["\\t"] = "\t",
-   ["\\\\"] = "\\",
-}
-function defs.string(str)
-   return string.gsub(str, "(\\[rnt\\])", strEscape)
 end
 function defs.literal(val)
    return { type = "Literal", value = val }


### PR DESCRIPTION
Fix some problems with string's escape sequences. The biggest problem was that \" and \' were not accepted. The new implementation is conform to the Lua syntax.

I'm not sure about how the error should be reported in case of wrong sequences but may be this can be fixed with a second commit.
