### PR TITLE
Fix problem with bytecode generation for fp numbers

### DIFF
--- a/bytecode.lua
+++ b/bytecode.lua
@@ -687,7 +687,7 @@ function Proto.__index:op_load(dest, val)
    elseif tv == 'string' then
       return self:emit(BC.KSTR, dest, self:const(val))
    elseif tv == 'number' then
-      if val < 0xffff then
+      if math.floor(val) == val and val < 0x8000 and val >= -0x8000 then
          return self:emit(BC.KSHORT, dest, val)
       else
          return self:emit(BC.KNUM, dest, self:const(val))


### PR DESCRIPTION
Hi Richard,

I've just fixed a problem with bytecode generation for floating point numbers.

Without the fix "print(3.14)" would print 3 which is a really crude approximation :-)

Francesco
