### PR TITLE
Fix bytecode generator to emit implicit return statement

### DIFF
--- a/bytecode.lua
+++ b/bytecode.lua
@@ -302,6 +302,7 @@ function Proto.new(flags, outer)
       firstline = 1;
       numlines  = 1;
       framesize = 0;
+      explret = false;
    }, Proto)
 end
 Proto.__index = { }
@@ -320,6 +321,9 @@ function Proto.__index:enter()
       freereg = self.freereg;
       __index = outer;
    })
+end
+function Proto.__index:is_root_scope()
+   return (getmetatable(self.actvars) == nil)
 end
 function Proto.__index:leave()
    local scope = assert(getmetatable(self.actvars), "cannot leave main scope")

--- a/generator/bytecode.lua
+++ b/generator/bytecode.lua
@@ -453,6 +453,9 @@ function match:FunctionExpression(node, dest)
       end
    end
    self:emit(node.body)
+   if not self.ctx.explret then
+      self.ctx:op_ret0()
+   end
 
    self.ctx = self.ctx.outer
    self.ctx:op_fnew(dest, func.idx)
@@ -612,6 +615,9 @@ function match:ReturnStatement(node)
       self.ctx:op_ret(base, narg)
    end
    self.ctx.freereg = free
+   if self.ctx:is_root_scope() then
+      self.ctx.explret = true
+   end
 end
 function match:Chunk(tree, name)
    for i=1, #tree.body do


### PR DESCRIPTION
Hi Richard,

now I beginning to understand the bytecode generator and it seems that I was even able to fix a bug. The Nyanga bytecode generator does not emit the instruction for the implicit return when required.

For example the following code raise an error:

``` lua
i = 0
n = 10
function count()
    if i < n then
        i = i + 1
        return i
    end
end

for k in count do
    print(k)
end
```

I propose a simple fix for this problem.

Francesco
