### PR TITLE
Fixed crash when parsing hex escape sequences

### DIFF
--- a/src/lang/tree.lua
+++ b/src/lang/tree.lua
@@ -58,7 +58,7 @@ function defs.escape(s)
    if escape_lookup[t] then return escape_lookup[t] end
    if string.sub(s, 1, 2) == '\\x' then
       local a = '0'..string.sub(s, 2)
-      return string.char(tonumber(n))
+      return string.char(tonumber(a))
    end
    if string.sub(s, 1, 2) == '\\u' then
       local a = '0x'..string.sub(s, 3, 4)


### PR DESCRIPTION
Fixed a typo which resulted in a crash when parsing hexadecimal escape sequences. 

Before:

```
$ shine
Shine 0.0.2 -- Copyright (C) 2013-2014 Richard Hundt.
shine> print("\x3a")
bad argument #1 to '?' (number expected, got nil)
```

After:

```
$ shine
Shine 0.0.2 -- Copyright (C) 2013-2014 Richard Hundt.
shine> print("\x3a")
:
```
