### PR TITLE
Fixed array.unshift

### DIFF
--- a/src/core/init.lua
+++ b/src/core/init.lua
@@ -314,9 +314,11 @@ local Array = class("Array", function(self)
       return v
    end
    function self.__members__:unshift(v)
-      for i = l - 1, 0 do
+      local l = self.length
+      for i = l - 1, 0, -1 do
          self[i + 1] = self[i]
       end
+      self.length = l + 1
       self[0] = v
    end
    function self.__members__:slice(offset, count)


### PR DESCRIPTION
Another fix. 

Before:

```
$ shine
Shine 0.0.2 -- Copyright (C) 2013-2014 Richard Hundt.
shine> a = [1, 2, 3]
shine> a.unshift(4)
[string "core"]:0: attempt to perform arithmetic on global 'l' (a nil value)
```

After:

```
$ shine
Shine 0.0.2 -- Copyright (C) 2013-2014 Richard Hundt.
shine> a = [1, 2, 3]
shine> a.unshift(4)
shine> print(a)
[4,1,2,3]
```
