### PR TITLE
lib/sys/unix.shn: d_namlen is from BSD; POSIX specifies d_name as nul…

### DIFF
--- a/lib/sys/unix.shn
+++ b/lib/sys/unix.shn
@@ -39,7 +39,7 @@ function readdir(dir is DIR)
    if ent == null then
       return null
    end
-   return ffi::string(ent.d_name, ent.d_namlen)
+   return ffi::string(ent.d_name)
 end
 
 function rewinddir(dir is DIR)


### PR DESCRIPTION
…l-terminated, so let ffi::string figure it out